### PR TITLE
Fix createReadPDU(), createWritePDU() throws

### DIFF
--- a/ModbusMaster/ModbusMaster.device.lib.nut
+++ b/ModbusMaster/ModbusMaster.device.lib.nut
@@ -1,6 +1,7 @@
 // MIT License
 //
-// Copyright 2017 Electric Imp
+// Copyright 2017-19 Electric Imp
+// Copyright 2020-23 KORE Wireless
 //
 // SPDX-License-Identifier: MIT
 //
@@ -23,7 +24,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 class ModbusMaster {
-    static VERSION = "1.0.1";
+    static VERSION = "1.0.2";
     _debug = null;
 
     //

--- a/ModbusRTU/ModbusRTU.device.lib.nut
+++ b/ModbusRTU/ModbusRTU.device.lib.nut
@@ -265,8 +265,26 @@ class ModbusRTU {
     // function to create PDU for read
     //
     static function createReadPDU(targetType, startingAddress, quantity) {
-        local PDU = blob(targetType.reqLen);
-        PDU.writen(targetType.fcode, 'b');
+        local pduType;
+        switch() {
+            case MODBUSRTU_TARGET_TYPE.COIL:
+                pduType = FUNCTION_CODES.read_coils;
+                break;
+            case MODBUSRTU_TARGET_TYPE.DISCRETE_INPUT:
+                pduType = FUNCTION_CODES.readInputs;
+                break;
+            case MODBUSRTU_TARGET_TYPE.INPUT_REGISTER:
+                pduType = FUNCTION_CODES.readInputRegs;
+                break;
+            case MODBUSRTU_TARGET_TYPE.HOLDING_REGISTER:
+                pduType = FUNCTION_CODES.readHoldingRegs;
+                break;
+            default:
+                throw "Incorrect targetType specified";
+        }
+        
+        local PDU = blob(pduType.reqLen);
+        PDU.writen(pduType.fcode, 'b');
         PDU.writen(swap2(startingAddress), 'w');
         PDU.writen(swap2(quantity), 'w');
         return PDU;
@@ -276,8 +294,20 @@ class ModbusRTU {
     // function to create PDU for write
     //
     static function createWritePDU(targetType, startingAddress, numBytes, quantity, values) {
+        local pduType;
+        switch() {
+            case MODBUSRTU_TARGET_TYPE.COIL:
+                pduType = FUNCTION_CODES.writeSingleCoil;
+                break;
+            case MODBUSRTU_TARGET_TYPE.HOLDING_REGISTER:
+                pduType = FUNCTION_CODES.writeSingleReg;
+                break;
+            default:
+                throw "Incorrect targetType specified";
+        }
+        
         local PDU = blob();
-        PDU.writen(targetType.fcode, 'b');
+        PDU.writen(pduType.fcode, 'b');
         PDU.writen(swap2(startingAddress), 'w');
         if (quantity > 1) {
             PDU.writen(swap2(quantity), 'w');

--- a/ModbusRTU/ModbusRTU.device.lib.nut
+++ b/ModbusRTU/ModbusRTU.device.lib.nut
@@ -1,6 +1,7 @@
 // MIT License
 //
-// Copyright 2017 Electric Imp
+// Copyright 2017-19 Electric Imp
+// Copyright 2020-23 KORE Wireless
 //
 // SPDX-License-Identifier: MIT
 //
@@ -84,7 +85,7 @@ enum MODBUSRTU_OBJECT_ID {
 }
 
 class ModbusRTU {
-    static VERSION = "1.0.1";
+    static VERSION = "1.0.2";
      // resLen and reqLen are the length of the PDU
     static FUNCTION_CODES = {
         readCoils = {
@@ -282,7 +283,7 @@ class ModbusRTU {
             default:
                 throw "Incorrect targetType specified";
         }
-        
+
         local PDU = blob(pduType.reqLen);
         PDU.writen(pduType.fcode, 'b');
         PDU.writen(swap2(startingAddress), 'w');
@@ -305,7 +306,7 @@ class ModbusRTU {
             default:
                 throw "Incorrect targetType specified";
         }
-        
+
         local PDU = blob();
         PDU.writen(pduType.fcode, 'b');
         PDU.writen(swap2(startingAddress), 'w');

--- a/ModbusRTU/ModbusRTU.device.lib.nut
+++ b/ModbusRTU/ModbusRTU.device.lib.nut
@@ -266,7 +266,7 @@ class ModbusRTU {
     //
     static function createReadPDU(targetType, startingAddress, quantity) {
         local pduType;
-        switch() {
+        switch(targetType) {
             case MODBUSRTU_TARGET_TYPE.COIL:
                 pduType = FUNCTION_CODES.read_coils;
                 break;
@@ -295,7 +295,7 @@ class ModbusRTU {
     //
     static function createWritePDU(targetType, startingAddress, numBytes, quantity, values) {
         local pduType;
-        switch() {
+        switch(targetType) {
             case MODBUSRTU_TARGET_TYPE.COIL:
                 pduType = FUNCTION_CODES.writeSingleCoil;
                 break;

--- a/ModbusRTU/README.md
+++ b/ModbusRTU/README.md
@@ -30,12 +30,12 @@ This method creates a PDU for *readData* operations. It takes the following para
 | *startingAddress* | Integer | Yes | N/A | The address from which it begins reading values |
 | *quantity* | Integer | Yes | N/A | The number of consecutive addresses the values are read from |
 
-| Type | Value | Access |
-| --- | --- | --- |
-| Coil | *MODBUSRTU_TARGET_TYPE.COIL* | Read-Write |
-| Discrete Input | *MODBUSRTU_TARGET_TYPE.DISCRETE_INPUT* | Read Only |
-| Input Register | *MODBUSRTU_TARGET_TYPE.INPUT_REGISTER* | Read Only |
-| Holding Register | *MODBUSRTU_TARGET_TYPE.HOLDING_REGISTER* | Read-Write |
+| Type | Value |
+| --- | --- |
+| Coil | *MODBUSRTU_TARGET_TYPE.COIL* |
+| Discrete Input | *MODBUSRTU_TARGET_TYPE.DISCRETE_INPUT* |
+| Input Register | *MODBUSRTU_TARGET_TYPE.INPUT_REGISTER* |
+| Holding Register | *MODBUSRTU_TARGET_TYPE.HOLDING_REGISTER* |
 
 #### Example
 
@@ -59,10 +59,10 @@ This method creates a PDU for *writeData* operations. It takes the following par
 | *quantity* | Integer | Yes | N/A | The number of consecutive addresses the values are written into |
 | *values* | Integer, array ([integer, boolean]), boolean, blob | Yes | N/A | The values written into Coils or Registers |
 
-| Type | Value | Access |
-| --- | --- | --- |
-| Coil | *MODBUSRTU_TARGET_TYPE.COIL* | Read-Write |
-| Holding Register | *MODBUSRTU_TARGET_TYPE.HOLDING_REGISTER* | Read-Write |
+| Type | Value |
+| --- | --- |
+| Coil | *MODBUSRTU_TARGET_TYPE.COIL* |
+| Holding Register | *MODBUSRTU_TARGET_TYPE.HOLDING_REGISTER* |
 
 #### Example
 

--- a/ModbusRTU/README.md
+++ b/ModbusRTU/README.md
@@ -59,6 +59,11 @@ This method creates a PDU for *writeData* operations. It takes the following par
 | *quantity* | Integer | Yes | N/A | The number of consecutive addresses the values are written into |
 | *values* | Integer, array ([integer, boolean]), boolean, blob | Yes | N/A | The values written into Coils or Registers |
 
+| Type | Value | Access |
+| --- | --- | --- |
+| Coil | *MODBUSRTU_TARGET_TYPE.COIL* | Read-Write |
+| Holding Register | *MODBUSRTU_TARGET_TYPE.HOLDING_REGISTER* | Read-Write |
+
 #### Example
 
 ```squirrel

--- a/ModbusRTU/README.md
+++ b/ModbusRTU/README.md
@@ -7,6 +7,8 @@ This library creates and parses Modbus Protocol Data Units (PDU). It depends on 
 * [ModbusSerialMaster](../ModbusMaster)
 * [ModbusTCPMaster](../ModbusSerialMaster)
 
+We recommend you work with one of these libraries unless your use case very specifically needs to perform PDU operations not provided by them. 
+
 **To use this library, add the following statements to the top of your device code:**
 
 ```

--- a/ModbusRTU/README.md
+++ b/ModbusRTU/README.md
@@ -2,7 +2,7 @@
 
 This library creates and parses Modbus Protocol Data Units (PDU). It depends on Electric Imp's [CRC16 library](https://github.com/electricimp/CRC16) to calculate the [CRC-16](https://en.wikipedia.org/wiki/Cyclic_redundancy_check) value of a string or blob.
 
-**Note** You will not usually work with this library directly, but load it as a dependency for one of our other Modbus libraries:
+**Note** You will not usually work with this library directly, but load it as a dependency for one of our other Modbus libraries, which target specific use cases:
 
 * [ModbusSerialMaster](../ModbusMaster)
 * [ModbusTCPMaster](../ModbusSerialMaster)

--- a/ModbusRTU/README.md
+++ b/ModbusRTU/README.md
@@ -2,6 +2,11 @@
 
 This library creates and parses Modbus Protocol Data Units (PDU). It depends on Electric Imp's [CRC16 library](https://github.com/electricimp/CRC16) to calculate the [CRC-16](https://en.wikipedia.org/wiki/Cyclic_redundancy_check) value of a string or blob.
 
+**Note** You will not usually work with this library directly, but load it as a dependency for one of our other Modbus libraries:
+
+* [ModbusSerialMaster](../ModbusMaster)
+* [ModbusTCPMaster](../ModbusSerialMaster)
+
 **To use this library, add the following statements to the top of your device code:**
 
 ```

--- a/ModbusSerialMaster/ModbusSerialMaster.device.lib.nut
+++ b/ModbusSerialMaster/ModbusSerialMaster.device.lib.nut
@@ -1,6 +1,7 @@
 // MIT License
 //
-// Copyright 2017 Electric Imp
+// Copyright 2017-19 Electric Imp
+// Copyright 2020-23 KORE Wireless
 //
 // SPDX-License-Identifier: MIT
 //
@@ -24,9 +25,9 @@
 
 class ModbusSerialMaster extends ModbusMaster {
 
-    static VERSION = "2.0.0";
+    static VERSION = "2.0.1";
     static MINIMUM_RESPONSE_LENGTH = 5;
-    
+
     _uart = null;
     _rts = null;
     _timeout = null;

--- a/ModbusSerialMaster/example/example.device.nut
+++ b/ModbusSerialMaster/example/example.device.nut
@@ -1,6 +1,7 @@
 // MIT License
 //
-// Copyright 2017 Electric Imp
+// Copyright 2017-19 Electric Imp
+// Copyright 2020-23 KORE Wireless
 //
 // SPDX-License-Identifier: MIT
 //
@@ -23,15 +24,15 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 #require "CRC16.class.nut:1.0.0"
-#require "ModbusRTU.device.lib.nut:1.0.1"
-#require "ModbusMaster.device.lib.nut:1.0.1"
-#require "ModbusSerialMaster.device.lib.nut:2.0.0"
+#require "ModbusRTU.device.lib.nut:1.0.2"
+#require "ModbusMaster.device.lib.nut:1.0.2"
+#require "ModbusSerialMaster.device.lib.nut:2.0.1"
 
-// Hardware used: Fieldbus Gateway and Kojo 
+// Hardware used: Fieldbus Gateway and Kojo
 // Click PLC C0-02DR-D connectied via RS485 ports
 
-// This example demonstrates how to write and read values 
-// into/from holding registers. 
+// This example demonstrates how to write and read values
+// into/from holding registers.
 
 const DEVICE_ADDRESS = 0x01;
 // instantiate the the Modbus485Master object

--- a/ModbusSerialSlave/ModbusSerialSlave.device.lib.nut
+++ b/ModbusSerialSlave/ModbusSerialSlave.device.lib.nut
@@ -1,6 +1,7 @@
 // MIT License
 //
-// Copyright 2017 Electric Imp
+// Copyright 2017-19 Electric Imp
+// Copyright 2020-23 KORE Wireless
 //
 // SPDX-License-Identifier: MIT
 //
@@ -23,7 +24,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 class ModbusSerialSlave extends ModbusSlave {
-    static VERSION = "2.0.0";
+    static VERSION = "2.0.1";
     static MIN_REQUEST_LENGTH = 4;
     _slaveID = null;
     _uart = null;

--- a/ModbusSerialSlave/example/device.example.nut
+++ b/ModbusSerialSlave/example/device.example.nut
@@ -1,6 +1,7 @@
 // MIT License
 //
-// Copyright 2017 Electric Imp
+// Copyright 2017-19 Electric Imp
+// Copyright 2020-23 KORE Wireless
 //
 // SPDX-License-Identifier: MIT
 //
@@ -23,13 +24,13 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 #require "CRC16.class.nut:1.0.0"
-#require "ModbusSlave.device.lib.nut:1.0.1"
-#require "ModbusSerialSlave.device.lib.nut:2.0.0"
+#require "ModbusSlave.device.lib.nut:1.0.2"
+#require "ModbusSerialSlave.device.lib.nut:2.0.1"
 
-// Hardware used: Fieldbus Gateway and Kojo 
+// Hardware used: Fieldbus Gateway and Kojo
 // Click PLC C0-02DR-D connectied via RS485 ports
 
-// This example demonstrates a holding register read. 
+// This example demonstrates a holding register read.
 
 const SLAVE_ID = 0x01;
 

--- a/ModbusSlave/ModbusSlave.device.lib.nut
+++ b/ModbusSlave/ModbusSlave.device.lib.nut
@@ -1,6 +1,7 @@
 // MIT License
 //
-// Copyright 2017 Electric Imp
+// Copyright 2017-19 Electric Imp
+// Copyright 2020-23 KORE Wireless
 //
 // SPDX-License-Identifier: MIT
 //
@@ -41,7 +42,7 @@ enum MODBUSSLAVE_EXCEPTION {
 }
 
 class ModbusSlave {
-    static VERSION = "1.0.1";
+    static VERSION = "1.0.2";
     static FUNCTION_CODES = {
         readCoil = {
             fcode = 0x01,

--- a/ModbusTCPMaster/ModbusTCPMaster.device.lib.nut
+++ b/ModbusTCPMaster/ModbusTCPMaster.device.lib.nut
@@ -1,6 +1,7 @@
 // MIT License
 //
-// Copyright 2017-2020 Electric Imp
+// Copyright 2017-19 Electric Imp
+// Copyright 2020-23 KORE Wireless
 //
 // SPDX-License-Identifier: MIT
 //
@@ -23,7 +24,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 class ModbusTCPMaster extends ModbusMaster {
-    static VERSION = "1.1.0";
+    static VERSION = "1.1.1";
     static MAX_TRANSACTION_COUNT = 65535;
     _transactions = null;
     _wiz = null;

--- a/ModbusTCPMaster/example/device.example.nut
+++ b/ModbusTCPMaster/example/device.example.nut
@@ -23,9 +23,9 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 #require "W5500.device.nut:1.0.0"
-#require "ModbusRTU.device.lib.nut:1.0.1"
-#require "ModbusMaster.device.lib.nut:1.0.1"
-#require "ModbusTCPMaster.device.lib.nut:1.1.0"
+#require "ModbusRTU.device.lib.nut:1.0.2"
+#require "ModbusMaster.device.lib.nut:1.0.2"
+#require "ModbusTCPMaster.device.lib.nut:1.1.1"
 
 // this example shows how to use readWriteMultipleRegisters
 


### PR DESCRIPTION
Funcrtion take a constant, but work with in internal set of nested `FUNCTION_CODE` tables. This patch maps the former to the latter so the lib doesn't throw errors,